### PR TITLE
Setup SPN and deploy core resource - script

### DIFF
--- a/IaC/Backend/core-resources.bicep
+++ b/IaC/Backend/core-resources.bicep
@@ -10,6 +10,18 @@ param TenantId string
 @description('AAD ObjectIds that need access to the TF resources')
 param ObjectIds array 
 
+@description('SPN DisplayName')
+param SPNName string
+
+@description('SPN Secret')
+@secure()
+param SPNSecret string
+
+@description('SPN Secret Expiry UnixTime')
+param SPNSecretExpiry int
+
+
+
 var stateStorageAccountName = 'tf${uniqueString(resourceGroup().id)}'
 var stateStorageAccountContainerName = 'tf-state'
 var stateKeyVault = 'tf-kv-${uniqueString(resourceGroup().id)}'
@@ -90,3 +102,19 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
     }
   }
 }
+
+resource secretAADSpn 'Microsoft.KeyVault/vaults/secrets@2023-02-01' ={
+  parent: keyVault
+  name: 'AADSpnSecret'
+  properties:{
+    value: SPNSecret
+    contentType: SPNName
+    attributes: {
+      enabled:true
+      exp:SPNSecretExpiry
+    }
+  }
+}
+
+output tf_state_storage_account_name string = tfStateStorageAccount.name
+output tf_state_storage_account_container_name string = tfStateStorageAccountContainer.name

--- a/IaC/Backend/deploy-core.ps1
+++ b/IaC/Backend/deploy-core.ps1
@@ -1,0 +1,51 @@
+  
+$cleanSubName = (az account show | ConvertFrom-Json).name -replace '[^a-zA-Z0-9 ]' , '_'
+$displayName = "IaC.AzSpn.Talk.$cleanSubName"
+$resourceGroupName = "Talk-IaC-DataEngineer.TerraformState"
+$location = "northeurope"
+
+
+# Setup AAD Application
+$existingAdApp = (az ad app list --display-name $displayName  | ConvertFrom-Json | Where-Object -Property displayName -eq $displayName | Select-Object -First 1)
+if (-not ($existingAdApp)) {
+    $existingAdApp = (az ad app create --display-name $displayName --sign-in-audience 'AzureADMyOrg' --enable-id-token-issuance true | ConvertFrom-Json)
+}
+
+
+# Setup AAD Application SPN
+$existingAdAppSpn = (az ad sp list --display-name $displayName | ConvertFrom-Json | Where-Object -Property appId -EQ $existingAdApp.appId)
+if(-not($existingAdAppSpn)){
+    $existingAdAppSpn = az ad sp create --id $existingAdApp.id
+}
+
+# Setup Credential
+$secretExpiresIn2Hours = (Get-Date).ToUniversalTime().AddHours(2)
+$secretExpiresIn2HoursUnix = [int64](Get-Date $secretExpiresIn2Hours  -UFormat %s)   
+$azADSecretsPlain = az ad app credential reset --id $existingAdApp.id --display-name 'rbac' --end-date $secretExpiresIn2Hours.ToString("yyyy-MM-ddTHH:mm:ss+00:00") | ConvertFrom-Json
+
+# Setup Backend Core Resources 
+$templateFile = "$PSScriptRoot/core-resources.bicep"
+$tenantId = (az account show | ConvertFrom-Json).tenantId
+
+$parameters = @{
+    "TenantId" = @{
+        "value" = $tenantId
+    };
+    "ObjectIds"            = @{
+        "value" = @($existingAdAppSpn.id)
+    };
+    "SPNName" = @{
+        "value" = $existingAdAppSpn.displayName
+    };
+    "SPNSecret" = @{
+        "value" = $azADSecretsPlain.password
+    };
+    "SPNSecretExpiry" = @{
+        "value" = $secretExpiresIn2HoursUnix
+    };
+    
+}
+
+az group create --name $resourceGroupName --location $location 
+az deployment group create --resource-group $resourceGroupName  --template-file $templateFile --parameters "$($parameters | ConvertTo-Json -Compress)"
+

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ### 1. Setup SPN
 
-- 🏗️ ToDo: Script to create an SPN
-- 🏗️ ToDo: Create RBAC with short term expiry
+- ✅ ToDo: Script to create an SPN
+- ✅ ToDo: Create RBAC with short term expiry
 - 🏗️ ToDo: Write Secret to KV 
 ### 2. Prepare IaC for Terraform
 


### PR DESCRIPTION
Updates: 

- Adding a deploy utility `./IaC/Backend/deploy-core.ps1`
   - Creates an SPN with a secure secret that expires in two hours
   - Secret is now stored in KV
- Updated `./IaC/Backend/core-resources.bicep` to now store the SPN secret